### PR TITLE
Pontuação de inimigo e asteroide diferenciadas corretamente

### DIFF
--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -16,7 +16,6 @@ public class Bullet : MonoBehaviour
     {
         if(col.gameObject.tag == "MainCamera")
         {
-            // Debug.Log("colidiu");
             Destroy(gameObject);
             // TO-DO: Adicionar restante do lifecicle
         }
@@ -25,16 +24,4 @@ public class Bullet : MonoBehaviour
             Destroy(gameObject);
         }
     }
-
-    // void OnTriggerEnter2D(Collider2D col)
-    // {
-    //     if(gameObject.tag != "Enemy")
-    //     {
-    //         if(col.tag == "Asteroid" || col.tag == "Enemy")
-    //         {
-    //             Destroy(gameObject);
-    //             Destroy(col.gameObject);
-    //         }
-    //     }
-    // }
 }

--- a/Assets/Scripts/DestroyByContatc.cs
+++ b/Assets/Scripts/DestroyByContatc.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 public class DestroyByContatc : MonoBehaviour
 {
-    private int scoreValue = 10;
+    private int asteroidScoreValue = 5;
+    private int enemyScoreValue = 10;
     private GameController gameController;
 
     void Start ()
@@ -27,15 +28,20 @@ public class DestroyByContatc : MonoBehaviour
         }
         if(gameObject.tag == "Bullet")
         {
-            if(other.tag == "Asteroid" || other.tag == "Enemy")
+            if(other.tag == "Asteroid")
             {
                 Destroy(gameObject);
                 Destroy(other.gameObject);
-                gameController.AddScore (scoreValue);
-                Debug.Log("pontuação aumenta");
+                gameController.AddScore (asteroidScoreValue);
+            }
+
+            if(other.tag == "Enemy")
+            {
+                Destroy(gameObject);
+                Destroy(other.gameObject);
+                gameController.AddScore (enemyScoreValue);
             }
         }
-        // Destroy(other.gameObject);
     }
 
     void OnCollisionEnter2D(Collision2D col)

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -27,26 +27,23 @@ public class GameController : MonoBehaviour
     public float waveWaitPowerUp;
     public Text scoreText;
     public int score;
-    // public float scrollSpeed = 1.5f;
 
-    // Start is called before the first frame update
     void Start()
     {
         score = 0;
-        UpdateScore();
+        UpdateScore ();
         StartCoroutine (SpawnEnemyWaves ());
         StartCoroutine (SpawnHazardWaves ());
         StartCoroutine (SpawnPowerUp ());
     }
 
-   IEnumerator SpawnEnemyWaves()
+    IEnumerator SpawnEnemyWaves()
     {
         yield return new WaitForSeconds (startWaitHazard);
         while (true)
         {
             for (int i = 0; i < enemyCount; i++)
             {
-                // GameObject enemy = enemies[Random.Range(0, enemies.Length)];
                 Vector3 spawnPosition = new Vector3 (Random.Range (-spawnValues.x, spawnValues.x) + 0.5f, spawnValues.y, spawnValues.z);
                 Quaternion spawnRotation = Quaternion.identity;
                 Instantiate (enemy, spawnPosition, spawnRotation);
@@ -73,7 +70,6 @@ public class GameController : MonoBehaviour
         {
             for (int i = 0; i < hazardCount; i++)
             {
-                // GameObject hazard = hazards[Random.Range(0, hazards.Length)];
                 Vector3 spawnPosition = new Vector3 (Random.Range (-spawnValues.x, spawnValues.x) + 0.5f, spawnValues.y, spawnValues.z);
                 Quaternion spawnRotation = Quaternion.identity;
                 Instantiate (hazard, spawnPosition, spawnRotation);
@@ -104,7 +100,6 @@ public class GameController : MonoBehaviour
     public void AddScore (int newScoreValue)
     {
         score += newScoreValue;
-        Debug.Log("pontuação aumenta: " + score);
         UpdateScore ();
     }
 


### PR DESCRIPTION
#1 
Resolução de bug ocorrendo na pontuação onde elementos de jogo diferentes conferiam a mesma pontuação.

**DestroyByContact.cs** (line 29):
```
 if(gameObject.tag == "Bullet")
{
    if(other.tag == "Asteroid")
    {
        Destroy(gameObject);
        Destroy(other.gameObject);
        gameController.AddScore (asteroidScoreValue);
    }

    if(other.tag == "Enemy")
    {
        Destroy(gameObject);
        Destroy(other.gameObject);
        gameController.AddScore (enemyScoreValue);
    }
}
```